### PR TITLE
Added support for paster deploy settings files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,3 +73,7 @@ env.gunicorn_worker_class
 env.django_settings_module
   This is special for django to set the DJANGO_SETTINGS_MODULE path.
   Example: ``mydjangoproject.settings``
+
+env.paster_config_file
+  This should point to your application.ini paster deploy settings file. Setting this will cause gunicorn to execute using gunicorn_paster instead of gunicorn.
+  Example: ``config/application.ini``

--- a/fabric_gunicorn.py
+++ b/fabric_gunicorn.py
@@ -8,7 +8,6 @@ from time import sleep
 from fabric import colors
 from fabric.api import task, env, run, cd
 from fabric.utils import abort, puts
-from fabric.contrib import files
 from fabric.context_managers import hide
 
 
@@ -81,7 +80,11 @@ def start():
             options.append('--worker-class %s' % env.gunicorn_worker_class)
         options_string = ' '.join(options)
 
-        run('%s gunicorn %s %s' % (prefix_string, options_string,
+        if 'paster_config_file' in env:
+            run('%s gunicorn_paster %s %s' % (prefix_string, options_string,
+                                   env.paster_config_file))
+        else:
+            run('%s gunicorn %s %s' % (prefix_string, options_string,
                                    env.gunicorn_wsgi_app))
 
         if gunicorn_running():

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup
 
 setup(
     name='fabric-gunicorn',
-    version='0.1',
+    version='0.2',
     url='http://github.com/jarus/fabric-gunicorn',
     license='BSD',
     author='Christoph Heer',


### PR DESCRIPTION
This allows you to run gunicorn using a paster deploy configuration instead of the default.
