### PR TITLE
Change fabric to fabric3 to support python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     long_description=__doc__,
     py_modules=['fabric_gunicorn'],
     install_requires=[
-        'fabric'
+        'fabric3'
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Python2.x will be marked as not supported in 2020. Fabric has support only for Python2.x. There is a fork of fabric called fabric3 which supports Python3.x and Python2.x. I think that would be great change the requirements of your package to fabric3